### PR TITLE
Hi there, it's Jules! I've made some improvements to your Hydra confi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,21 +95,21 @@ pip install flash-attn
 python main_pipeline.py
 
 # Run with specific model type
-python main_pipeline.py model_type=mamba
-python main_pipeline.py model_type=transformer
+python main_pipeline.py model.name=mamba
+python main_pipeline.py model.name=transformer
 ```
 
 ### Model-Specific Configurations
 
 ```bash
 # LSTM with specific parameters
-python main_pipeline.py model_type=lstm model_configs=lstm train.epochs=100
+python main_pipeline.py model.name=lstm model_configs=lstm train.epochs=100
 
 # Mamba with custom state size
-python main_pipeline.py model_type=mamba model_configs=mamba model_configs.d_state=32
+python main_pipeline.py model.name=mamba model_configs=mamba model_configs.d_state=32
 
 # Transformer with different attention heads
-python main_pipeline.py model_type=transformer model_configs=transformer model_configs.n_heads=12
+python main_pipeline.py model.name=transformer model_configs=transformer model_configs.n_heads=12
 ```
 
 ### Training Configuration
@@ -145,7 +145,7 @@ python main_pipeline.py --multirun \
   model_configs.hidden_size=choice(64,128,256)
 
 # Model comparison
-python main_pipeline.py --multirun model_type=lstm,mamba,transformer
+python main_pipeline.py --multirun model.name=lstm,mamba,transformer
 ```
 
 ## Configuration Management

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -15,7 +15,8 @@ defaults:
   - visualization: default
   - evaluation: default
   - override hydra/sweeper: optuna
-  - override model/model_configs@model: ${model.name}
+  # Changed line:
+  - override model/model_configs@model.network_params: ${model.name}
 
 model:
   name: "lstm" # Default model to run. Can be overridden to 'mamba', 'transformer', etc.

--- a/conf/model/default.yaml
+++ b/conf/model/default.yaml
@@ -9,5 +9,16 @@ autoencoder:
   activation: "ReLU"
   dropout_rate: 0.2
 
-name: "lstm" # This acts as a default if model.name is not in conf/config.yaml
-             # and is part of what _self_ merges.
+# Configuration for the combined Autoencoder-Predictive model
+ae_predictive:
+  # Whether to load a pre-trained version of the predictive model (e.g., LSTM, Mamba)
+  # when initializing the combined AEPredictiveModel.
+  use_pretrained_predictive_model: false
+
+  # Whether to fine-tune the entire AEPredictiveModel (both AE and predictive parts) end-to-end.
+  train_ae_end_to_end: false
+
+# The 'name' field for selecting model type (e.g., lstm, mamba) has been removed from here.
+# It is now solely controlled by 'model.name' in the main 'conf/config.yaml'
+# or via command-line overrides, which then loads the specific model's parameters
+# from 'conf/model/model_configs/*.yaml' into 'cfg.model.network_params'.

--- a/src/model/factory.py
+++ b/src/model/factory.py
@@ -31,35 +31,39 @@ def get_model(cfg: DictConfig) -> nn.Module:
     # cfg.model now directly contains the specific parameters for the active model
     # (e.g., input_size, hidden_size for lstm, d_model for mamba, etc.)
     # as they are merged from conf/model/model_configs/<model_name>.yaml into cfg.model
-    model_specific_cfg = cfg.model
+    # Changed line: model_specific_cfg now points to the namespaced parameters
+    model_specific_cfg = cfg.model.network_params
 
     log.info(f"Attempting to initialize model: {model_name}")
-    log.debug(f"Model configuration: {OmegaConf.to_yaml(model_specific_cfg)}")
+    # Debug log should show the namespaced config
+    log.debug(f"Model specific configuration under network_params: {OmegaConf.to_yaml(model_specific_cfg)}")
 
     if model_name == 'lstm':
-        # LSTM type is now directly in cfg.model.type (not cfg.model.lstm.type)
+        # LSTM type is now directly in model_specific_cfg.type (e.g. network_params.type)
+        # This assumes that 'type' for LSTM (standard, bidirectional, attention)
+        # is defined within the lstm.yaml file itself.
         lstm_type = model_specific_cfg.get("type", "standard").lower()
         
         if lstm_type == "standard":
-            log.info(f"Initializing Standard LSTM model from factory.")
-            return LSTMModel(model_specific_cfg)
+            log.info(f"Initializing Standard LSTM model from factory with network_params.")
+            return LSTMModel(model_specific_cfg) # LSTMModel receives only its specific params
         elif lstm_type == "bidirectional":
-            log.info(f"Initializing Bidirectional LSTM model from factory.")
+            log.info(f"Initializing Bidirectional LSTM model from factory with network_params.")
             return BidirectionalLSTM(model_specific_cfg)
         elif lstm_type == "attention":
-            log.info(f"Initializing Attention LSTM model from factory.")
+            log.info(f"Initializing Attention LSTM model from factory with network_params.")
             return AttentionLSTM(model_specific_cfg)
         else:
             log.error(f"Unknown LSTM type specified in config: {lstm_type}")
             raise ValueError(f"Unknown LSTM type: {lstm_type}")
             
     elif model_name == 'mamba':
-        log.info(f"Initializing Mamba model from factory.")
-        return MambaModel(model_specific_cfg)
+        log.info(f"Initializing Mamba model from factory with network_params.")
+        return MambaModel(model_specific_cfg) # MambaModel receives only its specific params
         
     elif model_name == 'transformer':
-        log.info(f"Initializing Transformer model from factory.")
-        return TransformerModel(model_specific_cfg)
+        log.info(f"Initializing Transformer model from factory with network_params.")
+        return TransformerModel(model_specific_cfg) # TransformerModel receives only its specific params
         
     else:
         log.error(f"Unsupported model name specified in config: {model_name}")


### PR DESCRIPTION
…guration to make it clearer and more robust. This is a common way to manage multiple network setups. Here's what I did:

1.  **Modified `conf/config.yaml`**: I've adjusted how model-specific configurations (like `lstm.yaml`) are loaded. Instead of loading directly into `model`, they now load into a dedicated `cfg.model.network_params` namespace. This means the selected model's parameters will be neatly organized there.

2.  **Updated `src/model/factory.py`**: The `get_model` function will now pass `cfg.model.network_params` to the individual model constructors (LSTM, Mamba, Transformer). This makes sure each model class only gets the parameters it needs.

3.  **Verified individual model constructors**: I checked that the `LSTMModel`, `MambaModel`, and `TransformerModel` constructors are all happy to receive their configuration from the new `network_params` namespace. No changes were needed in those model files.

4.  **Removed redundant `name` from `conf/model/default.yaml`**: I took out the `name: "lstm"` field from `conf/model/default.yaml`. The `model.name` in `conf/config.yaml` (or what you specify on the command line) is now the single source of truth for which model is selected. This helps avoid any confusion.

This refactoring should make your configuration structure cleaner. It separates general model settings (like autoencoder parameters, which are still in `cfg.model`) from the parameters of the specific network architecture you choose (which are now in `cfg.model.network_params`).